### PR TITLE
Patch Cluster Autoscaler 1.15.0

### DIFF
--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -573,6 +573,10 @@ func (csr *ClusterStateRegistry) updateReadinessStats(currentTime time.Time) {
 			klog.Warningf("Failed to get nodegroup for %s: %v", unregistered.Node.Name, errNg)
 			continue
 		}
+		if nodeGroup == nil {
+			klog.Warningf("Nodegroup is nil for %s", unregistered.Node.Name)
+			continue
+		}
 		perNgCopy := perNodeGroup[nodeGroup.Id()]
 		if unregistered.UnregisteredSince.Add(csr.config.MaxNodeProvisionTime).Before(currentTime) {
 			perNgCopy.LongUnregistered++

--- a/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
+++ b/cluster-autoscaler/clusterstate/utils/node_instances_cache.go
@@ -103,7 +103,9 @@ func (cache *CloudProviderNodeInstancesCache) GetCloudProviderNodeInstances() (m
 			go func() {
 				defer wg.Done()
 				_, err := cache.fetchCloudProviderNodeInstancesForNodeGroup(nodeGroup)
-				klog.Errorf("Failed to fetch cloud provider node instances for %v, error %v", nodeGroup.Id(), err)
+				if err != nil {
+					klog.Errorf("Failed to fetch cloud provider node instances for %v, error %v", nodeGroup.Id(), err)
+				}
 			}()
 		}
 	}


### PR DESCRIPTION
* Cherry-pick bugfixes from master.
* Allow balanced scale-up of ASGs with similar instance types. Memory capacity can differ ±2.5% between m4.2xlarge and m5.2xlarge.